### PR TITLE
Features: start Syncthing, open file browser

### DIFF
--- a/start-syncthing.sh
+++ b/start-syncthing.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## Uncomment one of the commands below and edit it with your Syncthing install path.
+## For more information try:
+## syncthing -help
+## https://github.com/syncthing/syncthing/wiki
+## https://forum.syncthing.net/c/howto
+
+## Example commands:
+# /path/to/syncthing -no-browser &
+# nice -n 19 ionice -c3 /path/to/syncthing -no-browser &
+# GOMAXPROCS=1 nice -n 19 ionice -c3 /path/to/syncthing -no-browser &

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -338,8 +338,9 @@ class Main(object):
             try:
                 for qitem in json_data:
                     self.process_event(qitem)
-            except ValueError:
-                log.warning('rest_receive_data: error parsing json in /rest/events')
+            except ValueError as e:
+                log.warning('rest_receive_data: error processing event ({})'.format(e))
+                log.debug(qitem)
                 self.set_state('error')
         else:
             fn = getattr(
@@ -423,7 +424,7 @@ class Main(object):
 
 
     def event_itemstarted(self, event):
-        log.debug('item started: {}'.format(event['data']['item']))
+        log.debug(u'item started: {}'.format(event['data']['item']))
         file_details = {'folder': event['data']['folder'],
                         'file': event['data']['item'],
                         'direction': 'down'}
@@ -437,7 +438,7 @@ class Main(object):
 
     def event_itemfinished(self, event):
         # TODO: test whether 'error' is null
-        log.debug('item finished: {}'.format(event['data']['item']))
+        log.debug(u'item finished: {}'.format(event['data']['item']))
         file_details = {'folder': event['data']['folder'],
                         'file': event['data']['item'],
                         'direction': 'down'}

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -22,6 +22,19 @@ from xml.dom import minidom
 
 VERSION = 'v0.3.0'
 
+def shorten_path(text, maxlength=80):
+    if len(text) <= maxlength:
+        return text
+    head, tail = os.path.split(text)
+    if len(tail) > maxlength:
+        return tail[:maxlength]  # TODO: separate file extension
+    while len(head) + len(tail) > maxlength:
+        head = '/'.join(head.split('/')[:-1])
+        if head == '':
+            return '.../' + tail
+    return head + '/.../' + tail
+
+
 class Main(object):
     def __init__(self):
         log.info('Started main procedure')
@@ -579,7 +592,9 @@ class Main(object):
             for child in self.current_files_submenu.get_children():
                 self.current_files_submenu.remove(child)
             for f in self.downloading_files:
-                mi = Gtk.MenuItem(u'\u2193 [{}] {}'.format(f['folder'], f['file']))
+                mi = Gtk.MenuItem(u'\u2193 [{}] {}'.format(
+                    f['folder'],
+                    shorten_path(f['file'])))
                 self.current_files_submenu.append(mi)
                 mi.show()
             self.current_files_menu.show()
@@ -598,7 +613,9 @@ class Main(object):
                     icon = u'\u2193'  # down arrow
                 mi = Gtk.MenuItem(
                     u'{icon} {time} [{folder}] {item}'.format(
-                        icon=icon, folder=f['folder'], item=f['file'],
+                        icon=icon,
+                        folder=f['folder'],
+                        item=shorten_path(f['file']),
                         time=self.convert_time(f['time'])
                         )
                     )

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -86,12 +86,12 @@ class Main(object):
         sep.show()
         self.menu.append(sep)
 
-        self.connected_devices_menu = Gtk.MenuItem('Devices')
-        self.connected_devices_menu.show()
-        self.connected_devices_menu.set_sensitive(False)
-        self.menu.append(self.connected_devices_menu)
-        self.connected_devices_submenu = Gtk.Menu()
-        self.connected_devices_menu.set_submenu(self.connected_devices_submenu)
+        self.devices_menu = Gtk.MenuItem('Devices')
+        self.devices_menu.show()
+        self.devices_menu.set_sensitive(False)
+        self.menu.append(self.devices_menu)
+        self.devices_submenu = Gtk.Menu()
+        self.devices_menu.set_submenu(self.devices_submenu)
 
         self.folder_menu = Gtk.MenuItem('Folders')
         self.folder_menu.show()
@@ -524,25 +524,25 @@ class Main(object):
 
 
     def update_devices(self):
-        self.connected_devices_menu.set_label('Devices (%s connected)' % self.count_connected())
+        self.devices_menu.set_label('Devices (%s connected)' % self.count_connected())
         if len(self.devices) == 0:
-            self.connected_devices_menu.set_label('Devices (0 connected)')
-            self.connected_devices_menu.set_sensitive(False)
+            self.devices_menu.set_label('Devices (0 connected)')
+            self.devices_menu.set_sensitive(False)
         else:
-            self.connected_devices_menu.set_sensitive(True)
+            self.devices_menu.set_sensitive(True)
 
-            if len(self.devices) == len(self.connected_devices_submenu) + 1:
-                # this updates the connected devices menu
-                for mi in self.connected_devices_submenu:
+            if len(self.devices) == len(self.devices_submenu) + 1:
+                # this updates the devices menu
+                for mi in self.devices_submenu:
                     for elm in self.devices:
                         if mi.get_label() == elm['name']:
                             mi.set_label(elm['name'])
                             mi.set_sensitive(elm['state'] == 'connected')
 
             else:
-                # this populates the connected devices menu with devices from config
-                for child in self.connected_devices_submenu.get_children():
-                    self.connected_devices_submenu.remove(child)
+                # this populates the devices menu with devices from config
+                for child in self.devices_submenu.get_children():
+                    self.devices_submenu.remove(child)
 
                 for nid in sorted(self.devices, key=lambda nid: nid['name']):
                     if nid['id'] == self.system_data.get('myID', None):
@@ -552,7 +552,7 @@ class Main(object):
 
                     mi = Gtk.MenuItem(nid['name'])
                     mi.set_sensitive(nid['state'] == 'connected')
-                    self.connected_devices_submenu.append(mi)
+                    self.devices_submenu.append(mi)
                     mi.show()
         self.state['update_devices'] = False
 

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -43,7 +43,6 @@ class Main(object):
         self.create_menu()
 
         self.downloading_files = []
-        self.uploading_files = []
         self.recent_files = []
         self.folders = []
         self.devices = []
@@ -104,12 +103,20 @@ class Main(object):
         self.folder_menu_submenu = Gtk.Menu()
         self.folder_menu.set_submenu(self.folder_menu_submenu)
 
-        self.current_files_menu = Gtk.MenuItem('Current files')
+        sep = Gtk.SeparatorMenuItem()
+        sep.show()
+        self.menu.append(sep)
+
+        self.current_files_menu = Gtk.MenuItem('Syncing')
+        self.current_files_menu.show()
+        self.current_files_menu.set_sensitive(False)
         self.menu.append(self.current_files_menu)
         self.current_files_submenu = Gtk.Menu()
         self.current_files_menu.set_submenu(self.current_files_submenu)
 
         self.recent_files_menu = Gtk.MenuItem('Recently synced')
+        self.recent_files_menu.show()
+        self.recent_files_menu.set_sensitive(False)
         self.menu.append(self.recent_files_menu)
         self.recent_files_submenu = Gtk.Menu()
         self.recent_files_menu.set_submenu(self.recent_files_submenu)
@@ -556,44 +563,39 @@ class Main(object):
         self.state['update_devices'] = False
 
     def update_files(self):
-        self.current_files_menu.set_label(u'Syncing \u2191 %s  \u2193 %s' % (
-            len(self.uploading_files), len(self.downloading_files)))
+        self.current_files_menu.set_label(u'Syncing %s files' % (
+            len(self.downloading_files)))
 
-        if (len(self.uploading_files), len(self.downloading_files)) == (0,0):
-            self.current_files_menu.hide()
+        if not self.downloading_files:
+            self.current_files_menu.set_sensitive(False)
             #self.set_state('idle')
         else:
-            # repopulate the current files menu
+            # Repopulate the current files menu
+            self.current_files_menu.set_sensitive(True)
             self.set_state('syncing')
             for child in self.current_files_submenu.get_children():
                 self.current_files_submenu.remove(child)
-            for f in self.uploading_files:
-                mi = Gtk.MenuItem(u'\u2191 [{}] {}'.format(f['folder'], f['file']))
-                self.current_files_submenu.append(mi)
-                mi.show()
             for f in self.downloading_files:
                 mi = Gtk.MenuItem(u'\u2193 [{}] {}'.format(f['folder'], f['file']))
                 self.current_files_submenu.append(mi)
                 mi.show()
             self.current_files_menu.show()
 
-        # repopulate the recent files menu
+        # Repopulate the recent files menu
         if not self.recent_files:
-            self.recent_files_menu.hide()
+            self.recent_files_menu.set_sensitive(False)
         else:
+            self.recent_files_menu.set_sensitive(True)
             for child in self.recent_files_submenu.get_children():
                 self.recent_files_submenu.remove(child)
             for f in self.recent_files:
-                updown = u'\u2193' u'\u2191'
                 if f['action'] == 'delete':
-                    action = '(Del)'
+                    icon = u'\u2612'  # [x]
                 else:
-                    action = updown
+                    icon = u'\u2193'  # down arrow
                 mi = Gtk.MenuItem(
-                    u'{time} [{folder}] {action} {item}'.format(
-                        action=action,
-                        folder=f['folder'],
-                        item=f['file'],
+                    u'{icon} {time} [{folder}] {item}'.format(
+                        icon=icon, folder=f['folder'], item=f['file'],
                         time=self.convert_time(f['time'])
                         )
                     )

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -341,7 +341,11 @@ class Main(object):
         if r.status_code != 200:
             log.warning('rest_receive_data: {0} failed ({1})'.format(
                 rest_path, r.status_code))
-            self.set_state('error')
+            if r.url == '/rest/system/upgrade':
+                # Debian/Ubuntu packages of Syncthing have this disabled
+                pass
+            else:
+                self.set_state('error')
             if rest_path == '/rest/system/ping':
                 # Basic version check: try the old REST path
                 GLib.idle_add(self.rest_get, '/rest/ping')

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -47,6 +47,8 @@ class Main(object):
         self.recent_files = []
         self.folders = []
         self.devices = []
+        self.errors = []
+
         self.last_ping = None
         self.system_data = {}
         self.syncthing_base = 'http://localhost:8080'
@@ -509,7 +511,8 @@ class Main(object):
 
 
     def process_rest_system_error(self, data):
-        if data['errors'] != []:
+        self.errors = data['errors']
+        if self.errors:
             log.info('{}'.format(data['errors']))
             self.mi_errors.show()
             self.set_state('error')
@@ -720,8 +723,8 @@ class Main(object):
         if not s:
             s = self.state['set_icon']
 
-        if s == 'error':
-            self.state['set_icon'] = s
+        if (s == 'error') or self.errors:
+            self.state['set_icon'] = 'error'
         else:
             self.state['set_icon'] = self.folder_check_state()
 

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -627,9 +627,7 @@ class Main(object):
 
 
     def update_folders(self):
-        if len(self.folders) == 0:
-            self.folder_menu.set_sensitive(False)
-        else:
+        if self.folders:
             self.folder_menu.set_sensitive(True)
             folder_maxlength = 0
             if len(self.folders) == len(self.folder_menu_submenu):
@@ -637,8 +635,17 @@ class Main(object):
                     for elm in self.folders:
                         folder_maxlength = max(folder_maxlength, len(elm['id']))
                         if str(mi.get_label()).split(' ', 1)[0] == elm['id']:
-                            if elm['state'] in ['scanning', 'syncing']:
-                                mi.set_label('{0}   ({1})'.format(elm['id'], elm['state']))
+                            if elm['state'] == 'scanning':
+                                mi.set_label('{} (scanning)'.format(elm['id']))
+                            elif elm['state'] == 'syncing':
+                                if elm.get('needFiles') > 1:
+                                    lbltext = '{fid} (syncing {num} files)'
+                                elif elm.get('needFiles') == 1:
+                                    lbltext = '{fid} (syncing {num} file)'
+                                else:
+                                    lbltext = '{fid} (syncing)'
+                                mi.set_label(lbltext.format(
+                                    fid=elm['id'], num=elm.get('needFiles')))
                             else:
                                 mi.set_label(elm['id'].ljust(folder_maxlength + 20))
             else:
@@ -649,6 +656,8 @@ class Main(object):
                     mi = Gtk.MenuItem(elm['id'].ljust(folder_maxlength + 20))
                     self.folder_menu_submenu.append(mi)
                     mi.show()
+        else:
+            self.folder_menu.set_sensitive(False)
         self.state['update_folders'] = False
 
 

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -231,8 +231,8 @@ class Main(object):
             for elem in folders:
                 if elem.hasAttribute('id') and elem.hasAttribute('path'):
                     self.folders.append({
-                        'folder': elem.getAttribute('id'),
-                        'directory': elem.getAttribute('path'),
+                        'id': elem.getAttribute('id'),
+                        'path': elem.getAttribute('path'),
                         'state': 'unknown',
                         })
         except:
@@ -357,7 +357,7 @@ class Main(object):
 
     def event_statechanged(self, event):
         for elem in self.folders:
-            if elem['folder'] == event['data']['folder']:
+            if elem['id'] == event['data']['folder']:
                 elem['state'] = event['data']['to']
                 self.state['update_folders'] = True
         self.set_state()
@@ -419,7 +419,7 @@ class Main(object):
                         'direction': 'down'}
         self.downloading_files.append(file_details)
         for elm in self.folders:
-            if elm['folder'] == event['data']['folder']:
+            if elm['id'] == event['data']['folder']:
                 elm['state'] = 'syncing'
         self.set_state()
         self.state['update_files'] = True
@@ -613,16 +613,16 @@ class Main(object):
             if len(self.folders) == len(self.folder_menu_submenu):
                 for mi in self.folder_menu_submenu:
                     for elm in self.folders:
-                        if str(mi.get_label()).split(' ', 1)[0] == elm['folder']:
+                        if str(mi.get_label()).split(' ', 1)[0] == elm['id']:
                             if elm['state'] in ['scanning', 'syncing']:
-                                mi.set_label('{0}   ({1})'.format(elm['folder'], elm['state']))
+                                mi.set_label('{0}   ({1})'.format(elm['id'], elm['state']))
                             else:
-                                mi.set_label(elm['folder'])
+                                mi.set_label(elm['id'])
             else:
                 for child in self.folder_menu_submenu.get_children():
                     self.folder_menu_submenu.remove(child)
                 for elm in self.folders:
-                    mi = Gtk.MenuItem(elm['folder'])
+                    mi = Gtk.MenuItem(elm['id'])
                     self.folder_menu_submenu.append(mi)
                     mi.show()
         self.state['update_folders'] = False

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -448,6 +448,7 @@ class Main(object):
         log.debug(u'item started: {}'.format(event['data']['item']))
         file_details = {'folder': event['data']['folder'],
                         'file': event['data']['item'],
+                        'type': event['data']['type'],
                         'direction': 'down'}
         self.downloading_files.append(file_details)
         for elm in self.folders:
@@ -461,6 +462,7 @@ class Main(object):
         log.debug(u'item finished: {}'.format(event['data']['item']))
         file_details = {'folder': event['data']['folder'],
                         'file': event['data']['item'],
+                        'type': event['data']['type'],
                         'direction': 'down'}
         try:
             self.downloading_files.remove(file_details)
@@ -470,8 +472,8 @@ class Main(object):
                 event['data']['item']))
         file_details['time'] = event['time']
         file_details['action'] = event['data']['action']
-        self.recent_files.append(file_details)
-        self.recent_files = self.recent_files[-20:]
+        self.recent_files.insert(0, file_details)
+        self.recent_files = self.recent_files[:20]
         self.state['update_files'] = True
 
     # end of the event processing dings

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -54,7 +54,7 @@ class Main(object):
         self.syncthing_base = 'http://localhost:8080'
         self.syncthing_version = ''
         self.device_name = ''
-        self.last_seen_id = int(0)
+        self.last_seen_id = 0
         self.rest_connected = False
         self.timeout_counter = 0
         self.ping_counter = 0
@@ -663,15 +663,15 @@ class Main(object):
             log.error("Couldn't run {}: {}".format(cmd, e))
             return
         self.state['update_st_running'] = True
-        self.last_seen_id = int(0)
+        self.last_seen_id = 0
 
     def syncthing_restart(self, *args):
         self.rest_post('/rest/system/restart')
-        self.last_seen_id = int(0)
+        self.last_seen_id = 0
 
     def syncthing_shutdown(self, *args):
         self.rest_post('/rest/system/shutdown')
-        self.last_seen_id = int(0)
+        self.last_seen_id = 0
 
 
     def convert_time(self, time):

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -621,19 +621,22 @@ class Main(object):
             self.folder_menu.set_sensitive(False)
         else:
             self.folder_menu.set_sensitive(True)
+            folder_maxlength = 0
             if len(self.folders) == len(self.folder_menu_submenu):
                 for mi in self.folder_menu_submenu:
                     for elm in self.folders:
+                        folder_maxlength = max(folder_maxlength, len(elm['id']))
                         if str(mi.get_label()).split(' ', 1)[0] == elm['id']:
                             if elm['state'] in ['scanning', 'syncing']:
                                 mi.set_label('{0}   ({1})'.format(elm['id'], elm['state']))
                             else:
-                                mi.set_label(elm['id'])
+                                mi.set_label(elm['id'].ljust(folder_maxlength + 20))
             else:
                 for child in self.folder_menu_submenu.get_children():
                     self.folder_menu_submenu.remove(child)
                 for elm in self.folders:
-                    mi = Gtk.MenuItem(elm['id'])
+                    folder_maxlength = max(folder_maxlength, len(elm['id']))
+                    mi = Gtk.MenuItem(elm['id'].ljust(folder_maxlength + 20))
                     self.folder_menu_submenu.append(mi)
                     mi.show()
         self.state['update_folders'] = False

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -186,7 +186,6 @@ class Main(object):
 
         self.ind.set_menu(self.menu)
 
-
     def load_config_begin(self):
         ''' Read needed values from config file '''
         confdir = GLib.get_user_config_dir()
@@ -284,7 +283,6 @@ class Main(object):
         GLib.timeout_add_seconds(TIMEOUT_REST, self.timeout_rest)
         GLib.timeout_add_seconds(TIMEOUT_EVENT, self.timeout_events)
 
-
     def syncthing_url(self, url):
         ''' Creates a url from given values and the address read from file '''
         return urlparse.urljoin(self.syncthing_base, url)
@@ -294,7 +292,6 @@ class Main(object):
 
     def open_releases_page(self, *args):
         webbrowser.open('https://github.com/syncthing/syncthing/releases')
-
 
     def rest_post(self, rest_path):
         log.debug('rest_post {}'.format(rest_path))
@@ -375,7 +372,6 @@ class Main(object):
                 'process_{}'.format(rest_path.strip('/').replace('/','_'))
                 )(json_data)
 
-
     # processing of the events coming from the event interface
     def process_event(self, event):
         t = event.get('type').lower()
@@ -422,14 +418,13 @@ class Main(object):
 
     def event_startupcomplete(self, event):
         self.set_state('idle')
-        time = self.convert_time(event['time'])
-        log.debug('Startup done at %s' % time)
+        log.info('Syncthing startup complete at %s' %
+            self.convert_time(event['time']))
         # Check config for added/removed devices or folders.
         GLib.idle_add(self.rest_get, '/rest/system/config')
 
     def event_ping(self, event):
         self.last_ping = dateutil.parser.parse(event['time'])
-        log.debug('A ping was sent at %s' % self.last_ping.strftime('%H:%M'))
 
     def event_devicediscovered(self, event):
         found = False
@@ -567,9 +562,7 @@ class Main(object):
             self.set_state('error')
         else:
             self.mi_errors.hide()
-
     # end of the REST processing functions
-
 
     def update(self):
         for func in self.state:
@@ -715,10 +708,8 @@ class Main(object):
             self.mi_restart_syncthing.set_sensitive(False)
             self.mi_shutdown_syncthing.set_sensitive(False)
 
-
     def count_connected(self):
         return len([e for e in self.devices if e['connected']])
-
 
     def syncthing_start(self, *args):
         cmd = os.path.join(self.wd, 'start-syncthing.sh')
@@ -729,23 +720,18 @@ class Main(object):
             log.error("Couldn't run {}: {}".format(cmd, e))
             return
         self.state['update_st_running'] = True
-        self.last_seen_id = 0
 
     def syncthing_restart(self, *args):
         self.rest_post('/rest/system/restart')
-        self.last_seen_id = 0
 
     def syncthing_shutdown(self, *args):
         self.rest_post('/rest/system/shutdown')
-        self.last_seen_id = 0
-
 
     def convert_time(self, time):
         return dateutil.parser.parse(time).strftime('%x %X')
 
     def calc_speed(self, old, new):
         return old / (new * 10)
-
 
     def license(self):
         with open(os.path.join(self.wd, 'LICENSE'), 'r') as f:
@@ -765,7 +751,6 @@ class Main(object):
         dialog.run()
         dialog.destroy()
 
-
     def set_state(self, s=None):
         if not s:
             s = self.state['set_icon']
@@ -776,7 +761,6 @@ class Main(object):
             self.state['set_icon'] = 'paused'
         else:
             self.state['set_icon'] = self.folder_check_state()
-
 
     def folder_check_state(self):
         state = {'syncing': 0, 'idle': 0, 'cleaning': 0, 'scanning': 0,
@@ -792,7 +776,6 @@ class Main(object):
         else:
             return 'idle'
 
-
     def set_icon(self):
         icon = {
         'updating': {'name': 'syncthing-client-updating', 'descr': 'Updating'},
@@ -807,12 +790,9 @@ class Main(object):
         self.ind.set_attention_icon(icon[self.state['set_icon']]['name'])
         self.ind.set_icon_full(icon[self.state['set_icon']]['name'],
                                icon[self.state['set_icon']]['descr'])
-        #GLib.timeout_add_seconds(1, self.set_icon)
-
 
     def leave(self, widget):
         Gtk.main_quit()
-
 
     def timeout_rest(self):
         self.timeout_counter = (self.timeout_counter + 1) % 10

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -36,8 +36,9 @@ def shorten_path(text, maxlength=80):
 
 
 class Main(object):
-    def __init__(self):
+    def __init__(self, args):
         log.info('Started main procedure')
+        self.args=args
         self.wd = os.path.normpath(os.path.abspath(os.path.split(__file__)[0]))
         self.icon_path = os.path.join(self.wd, 'icons')
         self.ind = appindicator.Indicator.new_with_path(
@@ -152,24 +153,26 @@ class Main(object):
         self.mi_start_syncthing = Gtk.MenuItem('Start Syncthing')
         self.mi_start_syncthing.connect('activate', self.syncthing_start)
         self.mi_start_syncthing.set_sensitive(False)
-        self.mi_start_syncthing.show()
         self.more_submenu.append(self.mi_start_syncthing)
 
         self.mi_restart_syncthing = Gtk.MenuItem('Restart Syncthing')
         self.mi_restart_syncthing.connect('activate', self.syncthing_restart)
         self.mi_restart_syncthing.set_sensitive(False)
-        self.mi_restart_syncthing.show()
         self.more_submenu.append(self.mi_restart_syncthing)
 
         self.mi_shutdown_syncthing = Gtk.MenuItem('Shutdown Syncthing')
         self.mi_shutdown_syncthing.connect('activate', self.syncthing_shutdown)
         self.mi_shutdown_syncthing.set_sensitive(False)
-        self.mi_shutdown_syncthing.show()
         self.more_submenu.append(self.mi_shutdown_syncthing)
 
         sep = Gtk.SeparatorMenuItem()
-        sep.show()
         self.more_submenu.append(sep)
+
+        if not self.args.no_shutdown:
+            self.mi_start_syncthing.show()
+            self.mi_restart_syncthing.show()
+            self.mi_shutdown_syncthing.show()
+            sep.show()
 
         self.about_menu = Gtk.MenuItem('About Indicator')
         self.about_menu.connect('activate', self.show_about)
@@ -825,9 +828,14 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--loglevel',
         choices=['debug', 'info', 'warning', 'error'], default='info')
-    parser.add_argument('--timeout-event', type=int, default=10)
-    parser.add_argument('--timeout-rest', type=int, default=30)
-    parser.add_argument('--timeout-gui', type=int, default=5)
+    parser.add_argument('--timeout-event', type=int, default=10, metavar='N',
+        help='Interval for polling event interface, in seconds. Default: %(default)s')
+    parser.add_argument('--timeout-rest', type=int, default=30, metavar='N',
+        help='Interval for polling REST interface, in seconds. Default: %(default)s')
+    parser.add_argument('--timeout-gui', type=int, default=5, metavar='N',
+        help='Interval for refreshing GUI, in seconds. Default: %(default)s')
+    parser.add_argument('--no-shutdown', action='store_true',
+        help='Hide Start, Restart, and Shutdown Syncthing menus')
 
     args = parser.parse_args()
     for arg in [args.timeout_event, args.timeout_rest, args.timeout_gui]:
@@ -846,5 +854,5 @@ if __name__ == '__main__':
     requests_log.setLevel(log.WARNING)
     requests_log.propagate = True
 
-    app = Main()
+    app = Main(args)
     Gtk.main()

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -273,7 +273,8 @@ class Main(object):
         log.debug('rest_post {}'.format(rest_path))
         headers = {'X-API-Key': self.api_key}
         if rest_path in ['/rest/system/restart', '/rest/system/shutdown']:
-            f = self.session.post(self.syncthing_url(rest_path), headers=headers)
+            f = self.session.post(
+                self.syncthing_url(rest_path), headers=headers)
         return False
 
     def rest_get(self, rest_path):
@@ -593,7 +594,7 @@ class Main(object):
                         self.devices_submenu.append(mi)
                         mi.show()
         else:
-            self.devices_menu.set_label('No devices)')
+            self.devices_menu.set_label('No devices')
             self.devices_menu.set_sensitive(False)
         self.state['update_devices'] = False
 
@@ -711,10 +712,10 @@ class Main(object):
         return len([e for e in self.devices if e['connected']])
 
     def syncthing_start(self, *args):
-        cmd = os.path.join(self.wd, 'start-syncthing.sh')
+        cmd = [os.path.join(self.wd, 'start-syncthing.sh')]
         log.info('Starting {}'.format(cmd))
         try:
-            proc = subprocess.Popen([cmd])
+            proc = subprocess.Popen(cmd)
         except Exception as e:
             log.error("Couldn't run {}: {}".format(cmd, e))
             return
@@ -743,7 +744,8 @@ class Main(object):
 
     def show_about(self, widget):
         dialog = Gtk.AboutDialog()
-        dialog.set_default_icon_from_file(os.path.join(self.icon_path, 'syncthing-client-idle.svg'))
+        dialog.set_default_icon_from_file(
+            os.path.join(self.icon_path, 'syncthing-client-idle.svg'))
         dialog.set_logo(None)
         dialog.set_program_name('Syncthing Ubuntu Indicator')
         dialog.set_version(VERSION)

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -447,7 +447,7 @@ class Main(object):
         file_details['time'] = event['time']
         file_details['action'] = event['data']['action']
         self.recent_files.append(file_details)
-        self.recent_files = self.recent_files[-5:]
+        self.recent_files = self.recent_files[-20:]
         self.state['update_files'] = True
 
     # end of the event processing dings

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -228,7 +228,7 @@ class Main(object):
                 if elem.hasAttribute('id') and elem.hasAttribute('path'):
                     self.folders.append({
                         'folder': elem.getAttribute('id'),
-                        'directory':  elem.getAttribute('path'),
+                        'directory': elem.getAttribute('path'),
                         'state': 'unknown',
                         })
         except:
@@ -664,11 +664,7 @@ class Main(object):
         if s == 'error':
             self.state['set_icon'] = s
         else:
-            rc = self.folder_check_state()
-            if rc != 'unknown':
-                self.state['set_icon'] = rc
-            else:
-                self.state['set_icon'] = s
+            self.state['set_icon'] = self.folder_check_state()
 
 
     def folder_check_state(self):
@@ -678,11 +674,10 @@ class Main(object):
 
         if state['syncing'] > 0:
             return 'syncing'
+        elif state['scanning'] > 0 or state['cleaning'] > 0:
+            return 'scanning'
         else:
-            if state['scanning'] > 0 or state['cleaning'] > 0:
-                return 'scanning'
-            else:
-                return 'idle'
+            return 'idle'
 
 
     def set_icon(self):

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -738,7 +738,8 @@ class Main(object):
         }
 
         self.ind.set_attention_icon(icon[self.state['set_icon']]['name'])
-        self.ind.set_icon_full(icon[self.state['set_icon']]['name'], icon[self.state['set_icon']]['descr'])
+        self.ind.set_icon_full(icon[self.state['set_icon']]['name'],
+                               icon[self.state['set_icon']]['descr'])
         #GLib.timeout_add_seconds(1, self.set_icon)
 
 
@@ -788,8 +789,10 @@ if __name__ == '__main__':
     TIMEOUT_GUI = args.timeout_gui
 
     # Setup logging:
-    loglevels = {'debug': log.DEBUG, 'info': log.INFO, 'warning': log.WARNING, 'error': log.ERROR}
-    log.basicConfig(format='%(asctime)s %(levelname)s: %(message)s', level=loglevels[args.loglevel])
+    loglevels = {'debug': log.DEBUG, 'info': log.INFO,
+                 'warning': log.WARNING, 'error': log.ERROR}
+    log.basicConfig(format='%(asctime)s %(levelname)s: %(message)s',
+                    level=loglevels[args.loglevel])
     requests_log = log.getLogger('urllib3.connectionpool')
     requests_log.setLevel(log.WARNING)
     requests_log.propagate = True

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -260,6 +260,14 @@ class Main(object):
         webbrowser.open('https://github.com/syncthing/syncthing/releases')
 
 
+    def rest_post(self, rest_path):
+        log.debug('rest_post {}'.format(rest_path))
+        headers = {'X-API-Key': self.api_key}
+        if rest_path in ['/rest/system/restart', '/rest/system/shutdown']:
+            f = self.session.post(self.syncthing_url(rest_path), headers=headers)
+        return False
+
+
     def rest_get(self, rest_path):
         log.debug('rest_get {}'.format(rest_path))
         # url for the included testserver: http://localhost:5115
@@ -695,14 +703,6 @@ class Main(object):
 
     def leave(self, widget):
         Gtk.main_quit()
-
-
-    def rest_post(self, rest_path):
-        log.debug('rest_post {}'.format(rest_path))
-        headers = {'X-API-Key': self.api_key}
-        if rest_path in ['/rest/system/restart', '/rest/system/shutdown']:
-            f = self.session.post(self.syncthing_url(rest_path), headers=headers)
-        return False
 
 
     def timeout_rest(self):

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -694,8 +694,9 @@ class Main(object):
         dialog.set_logo(None)
         dialog.set_program_name('Syncthing Ubuntu Indicator')
         dialog.set_version(VERSION)
-        dialog.set_website('http://www.syncthing.net')
-        dialog.set_comments('This menu applet for systems supporting AppIndicator can show the status of a Syncthing instance')
+        dialog.set_website('https://github.com/icaruseffect/syncthing-ubuntu-indicator')
+        dialog.set_comments('This menu applet for systems supporting AppIndicator'
+            '\ncan show the status of a Syncthing instance')
         dialog.set_license(self.license())
         dialog.run()
         dialog.destroy()

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -615,6 +615,11 @@ class Main(object):
                     f['folder'],
                     shorten_path(f['file'])))
                 self.current_files_submenu.append(mi)
+                mi.connect(
+                    'activate',
+                    self.open_file_browser,
+                    os.path.split(
+                        self.get_full_path(f['folder'], f['file']))[0])
                 mi.show()
             self.current_files_menu.show()
 
@@ -640,6 +645,11 @@ class Main(object):
                         )
                     )
                 self.recent_files_submenu.append(mi)
+                mi.connect(
+                    'activate',
+                    self.open_file_browser,
+                    os.path.split(
+                        self.get_full_path(f['folder'], f['file']))[0])
                 mi.show()
             self.recent_files_menu.show()
         self.state['update_files'] = False
@@ -672,6 +682,7 @@ class Main(object):
                 for elm in self.folders:
                     folder_maxlength = max(folder_maxlength, len(elm['id']))
                     mi = Gtk.MenuItem(elm['id'].ljust(folder_maxlength + 20))
+                    mi.connect('activate', self.open_file_browser, elm['path'])
                     self.folder_menu_submenu.append(mi)
                     mi.show()
         else:
@@ -803,6 +814,21 @@ class Main(object):
         if self.count_connection_error == 0:
             GLib.idle_add(self.rest_get, '/rest/events')
         return True
+
+    def open_file_browser(self, menuitem, path):
+        if not os.path.isdir(path):
+            log.debug('Not a directory, or does not exist: {}'.format(path))
+            return
+        try:
+            proc = subprocess.Popen(['xdg-open', path])
+        except Exception as e:
+            log.error("Couldn't open file browser for {} ({})".format(path, e))
+
+    def get_full_path(self, folder, item):
+        for elem in self.folders:
+            if elem['id'] == folder:
+                a = elem['path']
+        return os.path.join(a, item)
 
 
 if __name__ == '__main__':

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -702,8 +702,9 @@ class Main(object):
 
     def update_st_running(self):
         if self.count_connection_error <= 1:
-            self.title_menu.set_label(u'Syncthing {0}  \u2022  {1}'.format(
-                self.syncthing_version, self.device_name))
+            if self.syncthing_version and self.device_name:
+                self.title_menu.set_label(u'Syncthing {0}  \u2022  {1}'.format(
+                    self.syncthing_version, self.device_name))
             self.mi_start_syncthing.set_sensitive(False)
             self.mi_restart_syncthing.set_sensitive(True)
             self.mi_shutdown_syncthing.set_sensitive(True)

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -805,9 +805,12 @@ if __name__ == '__main__':
     TIMEOUT_REST = args.timeout_rest
     TIMEOUT_GUI = args.timeout_gui
 
-    # setup debugging:
+    # Setup logging:
     loglevels = {'debug': log.DEBUG, 'info': log.INFO, 'warning': log.WARNING, 'error': log.ERROR}
     log.basicConfig(format='%(asctime)s %(levelname)s: %(message)s', level=loglevels[args.loglevel])
+    requests_log = log.getLogger('urllib3.connectionpool')
+    requests_log.setLevel(log.WARNING)
+    requests_log.propagate = True
 
     app = Main()
     Gtk.main()

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -13,7 +13,8 @@ import urlparse
 import webbrowser
 
 import pytz
-import requests
+import requests   # used only to catch exceptions
+import socket     # used only to catch exceptions
 from requests_futures.sessions import FuturesSession
 from gi.repository import Gtk, Gio, GLib
 from gi.repository import AppIndicator3 as appindicator
@@ -308,8 +309,8 @@ class Main(object):
             if self.ping_counter > 1:
                 self.set_state('error')
             return
-        except requests.exceptions.Timeout:
-            log.warning('Connection timeout')
+        except (requests.exceptions.Timeout, socket.timeout):
+            log.warning('Timeout')
             return
         except Exception as e:
             log.error('exception: {}'.format(e))

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -419,13 +419,14 @@ class Main(object):
     def event_starting(self, event):
         self.set_state('paused')
         log.info('Received that Syncthing was starting at %s' % event['time'])
+        # Check for added/removed devices or folders.
+        GLib.idle_add(self.rest_get, '/rest/system/config')
+        GLib.idle_add(self.rest_get, '/rest/system/version')
 
     def event_startupcomplete(self, event):
         self.set_state('idle')
         log.info('Syncthing startup complete at %s' %
             self.convert_time(event['time']))
-        # Check config for added/removed devices or folders.
-        GLib.idle_add(self.rest_get, '/rest/system/config')
 
     def event_ping(self, event):
         self.last_ping = dateutil.parser.parse(event['time'])

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -38,7 +38,7 @@ class Main(object):
                       'update_devices': True,
                       'update_files': True,
                       'update_st_running': False,
-                      'set_icon': 'idle'}
+                      'set_icon': 'paused'}
         self.set_icon()
         self.create_menu()
 
@@ -309,7 +309,7 @@ class Main(object):
             self.rest_connected = False
             self.state['update_st_running'] = True
             if self.ping_counter > 1:
-                self.set_state('error')
+                self.set_state('paused')
             return
         except (requests.exceptions.Timeout, socket.timeout):
             log.warning('Timeout')
@@ -725,6 +725,8 @@ class Main(object):
 
         if (s == 'error') or self.errors:
             self.state['set_icon'] = 'error'
+        elif not self.rest_connected:
+            self.state['set_icon'] = 'paused'
         else:
             self.state['set_icon'] = self.folder_check_state()
 

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -692,9 +692,9 @@ class Main(object):
 
 
     def license(self):
-        with open('LICENSE', 'r') as f:
-            license = f.read()
-        return license
+        with open(os.path.join(self.wd, 'LICENSE'), 'r') as f:
+            lic = f.read()
+        return lic
 
 
     def show_about(self, widget):

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -487,6 +487,14 @@ class Main(object):
     # end of the REST processing functions
 
 
+    def update(self):
+        for func in self.state:
+            if self.state[func]:
+                log.debug('self.update {}'.format(func))
+                start = getattr(self, '%s' % func)()
+        return True
+
+
     def update_last_checked(self, isotime):
         #dt = dateutil.parser.parse(isotime)
         #self.last_checked_menu.set_label('Last checked: %s' % (dt.strftime('%H:%M'),))
@@ -532,27 +540,6 @@ class Main(object):
                     self.connected_devices_submenu.append(mi)
                     mi.show()
         self.state['update_devices'] = False
-
-
-    def update_title_menu(self):
-        self.title_menu.set_label(u'Syncthing {0}  \u2022  {1}'.format(
-            self.syncthing_version, self.device_name))
-
-
-    def count_connected(self):
-        return len([e for e in self.devices if e['state'] == 'connected'])
-
-
-    def syncthing_restart(self, *args):
-        self.rest_post('/rest/system/restart')
-
-
-    def syncthing_shutdown(self, *args):
-        self.rest_post('/rest/system/shutdown')
-
-
-    def convert_time(self, time):
-        return dateutil.parser.parse(time).strftime('%x %X')
 
 
     def update_files(self):
@@ -626,6 +613,27 @@ class Main(object):
         self.state['update_folders'] = False
 
 
+    def update_title_menu(self):
+        self.title_menu.set_label(u'Syncthing {0}  \u2022  {1}'.format(
+            self.syncthing_version, self.device_name))
+
+
+    def count_connected(self):
+        return len([e for e in self.devices if e['state'] == 'connected'])
+
+
+    def syncthing_restart(self, *args):
+        self.rest_post('/rest/system/restart')
+
+
+    def syncthing_shutdown(self, *args):
+        self.rest_post('/rest/system/shutdown')
+
+
+    def convert_time(self, time):
+        return dateutil.parser.parse(time).strftime('%x %X')
+
+
     def calc_speed(self, old, new):
         return old / (new * 10)
 
@@ -647,14 +655,6 @@ class Main(object):
         dialog.set_license(self.license())
         dialog.run()
         dialog.destroy()
-
-
-    def update(self):
-        for func in self.state:
-            if self.state[func]:
-                log.debug('self.update {}'.format(func))
-                start = getattr(self, '%s' % func)()
-        return True
 
 
     def set_state(self, s=None):

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -410,14 +410,14 @@ class Main(object):
         for elem in self.devices:
             if event['data']['id'] == elem['id']:
                 elem['state'] = 'connected'
-                log.debug('device %s connected' % elem['name'])
+                log.info('Device connected: %s' % elem['name'])
         self.state['update_devices'] = True
 
     def event_devicedisconnected(self, event):
         for elem in self.devices:
             if event['data']['id'] == elem['id']:
                 elem['state'] = 'disconnected'
-                log.debug('device %s disconnected' % elem['name'])
+                log.info('Device disconnected: %s' % elem['name'])
         self.state['update_devices'] = True
 
     def event_itemstarted(self, event):

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -177,7 +177,6 @@ class Main(object):
         f.load_contents_async(None, self.load_config_finish)
         return False
 
-
     def load_config_finish(self, fp, async_result):
         try:
             success, data, etag = fp.load_contents_finish(async_result)
@@ -284,7 +283,6 @@ class Main(object):
             f = self.session.post(self.syncthing_url(rest_path), headers=headers)
         return False
 
-
     def rest_get(self, rest_path):
         log.debug('rest_get {}'.format(rest_path))
         # url for the included testserver: http://localhost:5115
@@ -298,7 +296,6 @@ class Main(object):
                              timeout=8)
         f.add_done_callback(self.rest_receive_data)
         return False
-
 
     def rest_receive_data(self, future):
         try:
@@ -364,10 +361,8 @@ class Main(object):
         fn = getattr(self, 'event_{}'.format(t), self.event_unknown_event)(event)
         self.update_last_seen_id(event.get('id', 0))
 
-
     def event_unknown_event(self, event):
         pass
-
 
     def event_statechanged(self, event):
         for elem in self.folders:
@@ -386,17 +381,14 @@ class Main(object):
         self.set_state('paused')
         log.info('Received that Syncthing was starting at %s' % event['time'])
 
-
     def event_startupcomplete(self, event):
         self.set_state('idle')
         time = self.convert_time(event['time'])
         log.debug('Startup done at %s' % time)
 
-
     def event_ping(self, event):
         self.last_ping = dateutil.parser.parse(event['time'])
         log.debug('A ping was sent at %s' % self.last_ping.strftime('%H:%M'))
-
 
     def event_devicediscovered(self, event):
         found = False
@@ -414,7 +406,6 @@ class Main(object):
                 })
         self.state['update_devices'] = True
 
-
     def event_deviceconnected(self, event):
         for elem in self.devices:
             if event['data']['id'] == elem['id']:
@@ -422,14 +413,12 @@ class Main(object):
                 log.debug('device %s connected' % elem['name'])
         self.state['update_devices'] = True
 
-
     def event_devicedisconnected(self, event):
         for elem in self.devices:
             if event['data']['id'] == elem['id']:
                 elem['state'] = 'disconnected'
                 log.debug('device %s disconnected' % elem['name'])
         self.state['update_devices'] = True
-
 
     def event_itemstarted(self, event):
         log.debug(u'item started: {}'.format(event['data']['item']))
@@ -442,7 +431,6 @@ class Main(object):
                 elm['state'] = 'syncing'
         self.set_state()
         self.state['update_files'] = True
-
 
     def event_itemfinished(self, event):
         # TODO: test whether 'error' is null
@@ -464,7 +452,6 @@ class Main(object):
 
     # end of the event processing dings
 
-
     # begin REST processing functions
 
     def process_rest_system_connections(self, data):
@@ -474,11 +461,9 @@ class Main(object):
                     nid['state'] = 'connected'
                     self.state['update_devices'] = True
 
-
     def process_rest_system_status(self, data):
         self.system_data = data
         self.state['update_st_running'] = True
-
 
     def process_rest_system_upgrade(self, data):
         if data['newer']:
@@ -488,11 +473,9 @@ class Main(object):
         else:
             self.syncthing_upgrade_menu.hide()
 
-
     def process_rest_system_version(self, data):
         self.syncthing_version = data['version']
         self.state['update_st_running'] = True
-
 
     def process_rest_system_ping(self, data):
         if data['ping'] == 'pong':
@@ -501,14 +484,12 @@ class Main(object):
             self.rest_connected = True
             self.ping_counter = 0
 
-
     def process_rest_ping(self, data):
         if data['ping'] == 'pong':
             # Basic version check
             log.error('Detected running Syncthing version < v0.11')
-            log.error('Syncthing v0.11.0-beta (or higher) required. Exiting.')
+            log.error('Syncthing v0.11 (or higher) required. Exiting.')
             self.leave()
-
 
     def process_rest_system_error(self, data):
         self.errors = data['errors']
@@ -529,12 +510,10 @@ class Main(object):
                 start = getattr(self, '%s' % func)()
         return True
 
-
     def update_last_checked(self, isotime):
         #dt = dateutil.parser.parse(isotime)
         #self.last_checked_menu.set_label('Last checked: %s' % (dt.strftime('%H:%M'),))
         pass
-
 
     def update_last_seen_id(self, lsi):
         if lsi > self.last_seen_id:
@@ -542,7 +521,6 @@ class Main(object):
         elif lsi < self.last_seen_id:
             log.warning('received event id {} less than last_seen_id {}'.format(
                 lsi, self.last_seen_id))
-
 
     def update_devices(self):
         self.devices_menu.set_label('Devices (%s connected)' % self.count_connected())
@@ -576,7 +554,6 @@ class Main(object):
                     self.devices_submenu.append(mi)
                     mi.show()
         self.state['update_devices'] = False
-
 
     def update_files(self):
         self.current_files_menu.set_label(u'Syncing \u2191 %s  \u2193 %s' % (
@@ -625,7 +602,6 @@ class Main(object):
             self.recent_files_menu.show()
         self.state['update_files'] = False
 
-
     def update_folders(self):
         if self.folders:
             self.folder_menu.set_sensitive(True)
@@ -660,7 +636,6 @@ class Main(object):
             self.folder_menu.set_sensitive(False)
         self.state['update_folders'] = False
 
-
     def update_st_running(self):
         if self.rest_connected:
             self.title_menu.set_label(u'Syncthing {0}  \u2022  {1}'.format(
@@ -690,11 +665,9 @@ class Main(object):
         self.state['update_st_running'] = True
         self.last_seen_id = int(0)
 
-
     def syncthing_restart(self, *args):
         self.rest_post('/rest/system/restart')
         self.last_seen_id = int(0)
-
 
     def syncthing_shutdown(self, *args):
         self.rest_post('/rest/system/shutdown')
@@ -704,7 +677,6 @@ class Main(object):
     def convert_time(self, time):
         return dateutil.parser.parse(time).strftime('%x %X')
 
-
     def calc_speed(self, old, new):
         return old / (new * 10)
 
@@ -713,7 +685,6 @@ class Main(object):
         with open(os.path.join(self.wd, 'LICENSE'), 'r') as f:
             lic = f.read()
         return lic
-
 
     def show_about(self, widget):
         dialog = Gtk.AboutDialog()

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -373,6 +373,11 @@ class Main(object):
                 self.state['update_folders'] = True
         self.set_state()
 
+    def event_foldersummary(self, event):
+        for elem in self.folders:
+            if elem['id'] == event['data']['folder']:
+                elem.update(event['data']['summary'])
+        self.state['update_folders'] = True
 
     def event_starting(self, event):
         self.set_state('paused')

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -467,7 +467,8 @@ class Main(object):
                         'file': event['data']['item'],
                         'type': event['data']['type'],
                         'direction': 'down'}
-        self.downloading_files.append(file_details)
+        if file_details not in self.downloading_files:
+            self.downloading_files.append(file_details)
         for elm in self.folders:
             if elm['id'] == event['data']['folder']:
                 elm['state'] = 'syncing'

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -548,23 +548,23 @@ class Main(object):
             self.last_seen_id = lsi
 
     def update_devices(self):
-        self.devices_menu.set_label('Devices (%s connected)' % self.count_connected())
-        if len(self.devices) == 0:
-            self.devices_menu.set_label('Devices (0 connected)')
+        if not self.devices:
+            self.devices_menu.set_label('No devices)')
             self.devices_menu.set_sensitive(False)
         else:
+            self.devices_menu.set_label('Devices ({}/{})'.format(
+                self.count_connected(), len(self.devices) - 1))
             self.devices_menu.set_sensitive(True)
 
             if len(self.devices) == len(self.devices_submenu) + 1:
-                # this updates the devices menu
+                # Update the devices menu
                 for mi in self.devices_submenu:
                     for elm in self.devices:
                         if mi.get_label() == elm['name']:
                             mi.set_label(elm['name'])
                             mi.set_sensitive(elm['state'] == 'connected')
-
             else:
-                # this populates the devices menu with devices from config
+                # Populate the devices menu with devices from config
                 for child in self.devices_submenu.get_children():
                     self.devices_submenu.remove(child)
 

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -712,9 +712,11 @@ class Main(object):
 
 
     def folder_check_state(self):
-        state = {'syncing': 0, 'idle': 0, 'cleaning': 0, 'scanning': 0, 'unknown': 0}
+        state = {'syncing': 0, 'idle': 0, 'cleaning': 0, 'scanning': 0,
+                 'unknown': 0}
         for elem in self.folders:
-            state[elem['state']] += 1
+            if elem['state'] in state:
+                state[elem['state']] += 1
 
         if state['syncing'] > 0:
             return 'syncing'

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -338,7 +338,7 @@ class Main(object):
             try:
                 for qitem in json_data:
                     self.process_event(qitem)
-            except ValueError as e:
+            except Exception as e:
                 log.warning('rest_receive_data: error processing event ({})'.format(e))
                 log.debug(qitem)
                 self.set_state('error')

--- a/syncthing-ubuntu-indicator.py
+++ b/syncthing-ubuntu-indicator.py
@@ -620,7 +620,7 @@ class Main(object):
         self.state['update_devices'] = False
 
     def update_files(self):
-        self.current_files_menu.set_label(u'Syncing %s files' % (
+        self.current_files_menu.set_label(u'Downloading %s files' % (
             len(self.downloading_files)))
 
         if not self.downloading_files:
@@ -647,14 +647,15 @@ class Main(object):
             self.recent_files_menu.set_sensitive(True)
             for child in self.recent_files_submenu.get_children():
                 self.recent_files_submenu.remove(child)
+            icons = {'delete': u'\u2612', # [x]
+                     'update': u'\u2193', # down arrow
+                     'dir': u'\U0001f4c1', # folder
+                     'file': u'\U0001f4c4', # file
+                     }
             for f in self.recent_files:
-                if f['action'] == 'delete':
-                    icon = u'\u2612'  # [x]
-                else:
-                    icon = u'\u2193'  # down arrow
                 mi = Gtk.MenuItem(
                     u'{icon} {time} [{folder}] {item}'.format(
-                        icon=icon,
+                        icon=icons.get(f['action'], 'unknown'),
                         folder=f['folder'],
                         item=shorten_path(f['file']),
                         time=self.convert_time(f['time'])


### PR DESCRIPTION
- Syncthing can now be launched from the indicator, as well as restarted and shutdown. This is intended for laptop users who may want to start and shutdown Syncthing when moving from place to place.
  - Customize start-syncthing.sh to enable this.
  - If you do not want to use this feature, you can hide the start, restart, and shutdown menu items by starting the indicator with the '--no-shutdown' option.
- Clicking an item in the 'Folders' or 'Recently updated' menus will open a file browser.
- The indicator turns red when there are errors reported by Syncthing (/rest/system/error). Open the web gui to view and clear them. 
- The indicator recognizes when Syncthing has been restarted and the list of devices/folders has changed. It is not necessary to restart the indicator when devices/folders are added/removed.
